### PR TITLE
Disable Haarp ability when stealing from archives

### DIFF
--- a/src/clj/game/cards/identities.clj
+++ b/src/clj/game/cards/identities.clj
@@ -542,7 +542,7 @@
 (define-card "Haarpsichord Studios: Entertainment Unleashed"
   (let [haarp (fn [state side card]
                 (if (and (agenda? card)
-                         (not= (:zone card) :discard))
+                         (not= (first (:zone card)) :discard))
                   ((constantly false)
                    (toast state :runner "Cannot steal due to Haarpsichord Studios." "warning"))
                   (constantly true)))]

--- a/test/clj/game/cards/identities_test.clj
+++ b/test/clj/game/cards/identities_test.clj
@@ -1263,6 +1263,7 @@
 
 (deftest haarpsichord-studios-entertainment-unleashed
   ;; Haarpsichord Studios
+
   (testing "Prevent stealing more than 1 agenda per turn"
     (do-game
       (new-game {:corp {:id "Haarpsichord Studios: Entertainment Unleashed"
@@ -1281,6 +1282,7 @@
       (score-agenda state :corp (get-content state :remote1 0))
       (click-prompt state :runner "Steal")
       (is (= 2 (:agenda-point (get-runner))) "Steal prevention didn't carry over to Corp turn")))
+
   (testing "Interactions with Employee Strike. Issue #1313"
     (do-game
       (new-game {:corp {:id "Haarpsichord Studios: Entertainment Unleashed"
@@ -1298,7 +1300,24 @@
       (play-from-hand state :runner "Scrubbed")
       (run-empty-server state "HQ")
       (click-prompt state :runner "No action")
-      (is (= 2 (:agenda-point (get-runner))) "Third steal prevented"))))
+      (is (= 2 (:agenda-point (get-runner))) "Third steal prevented")))
+
+  (testing "Haarp is disabled for archives"
+    (do-game
+      (new-game {:corp {:id "Haarpsichord Studios: Entertainment Unleashed"
+                        :discard ["15 Minutes"]
+                        :deck [(qty "15 Minutes" 1)]}
+                 :runner {:deck []}})
+      (take-credits state :corp)
+
+      (run-empty-server state "HQ")
+      (click-prompt state :runner "Steal")
+      (is (= 1 (:agenda-point (get-runner))))
+
+      (run-empty-server state "Archives")
+      (click-prompt state :runner "Steal")
+
+      (is (= 2 (:agenda-point (get-runner))) "Archives steal not prevented"))))
 
 (deftest haas-bioroid-architects-of-tomorrow
   ;; Architects of Tomorrow - prompt to rez after passing bioroid


### PR DESCRIPTION
It looks like a :zone is always a vector, to handle remote servers. I haven't tried Pawn yet, but I think it's the same thing going on there.

This is how I ran the new test; I'm sure there's a way to do this that uses the Docker volume correctly, but I don't know it yet.
```sh
lein fetch --no-card-images --no-db --local ../path/to/netrunner-data/
lein eftest :only game.cards.identities-test/haarpsichord-studios-entertainment-unleashed
```